### PR TITLE
Fix popup menu items lost after construction, plus two layout issues

### DIFF
--- a/vecgui/nodes/ui/button/menu_button.cpp
+++ b/vecgui/nodes/ui/button/menu_button.cpp
@@ -39,7 +39,11 @@ std::weak_ptr<PopupMenu> MenuButton::get_popup_menu() const {
 void MenuButton::calc_minimum_size() {
     Button::calc_minimum_size();
 
-    calculated_minimum_size.x = std::max(menu->get_effective_minimum_size().x, calculated_minimum_size.x);
+    // Deliberately not widened to the popup's width. Adopting it means a single long
+    // item forces the button - and every container holding it, e.g. a sidebar - to grow
+    // to that width, even while the item is not selected. The popup keeps its own
+    // natural width and simply overhangs the button, which is how dropdowns behave
+    // elsewhere, so long entries stay fully readable without distorting the layout.
 }
 
 void MenuButton::connect_signal(const std::string& signal, const AnyCallable<void>& callback) {

--- a/vecgui/nodes/ui/popup_menu.cpp
+++ b/vecgui/nodes/ui/popup_menu.cpp
@@ -79,8 +79,10 @@ void PopupMenu::adjust_layout() {
     size = size.max(calculated_minimum_size);
 
     float window_height = 0;
+    float window_width = 0;
     if (tree_) {
         window_height = tree_->get_view_size().y;
+        window_width = tree_->get_view_size().x;
     }
 
 #ifdef VECGUI_USE_WINDOW
@@ -91,6 +93,7 @@ void PopupMenu::adjust_layout() {
         auto window = window_builder->get_window(get_window_index());
         if (!window.expired()) {
             window_height = window.lock()->get_logical_size().y;
+            window_width = window.lock()->get_logical_size().x;
         }
     }
 #endif
@@ -115,11 +118,20 @@ void PopupMenu::adjust_layout() {
         }
     }
 
+    // A popup may legitimately be wider than the button that opened it. Anchor it to
+    // the button's left edge when there is room, otherwise let it extend leftwards so
+    // it stays fully on screen - a button in a right-hand sidebar would otherwise push
+    // most of the list off the window.
+    float menu_x = popup_position.x;
+    if (window_width > 0.0f && menu_x + menu_width > window_width) {
+        menu_x = std::max(0.0f, window_width - menu_width);
+    }
+
     if (drop_down) {
-        set_position(popup_position + Vec2F{0, button_height});
+        set_position({menu_x, popup_position.y + button_height});
         size = {menu_width, actual_menu_height};
     } else {
-        set_position(popup_position - Vec2F{0, actual_menu_height});
+        set_position({menu_x, popup_position.y - actual_menu_height});
         size = {menu_width, actual_menu_height};
     }
 

--- a/vecgui/nodes/ui/popup_menu.cpp
+++ b/vecgui/nodes/ui/popup_menu.cpp
@@ -178,6 +178,13 @@ void PopupMenu::create_item(const std::string &text) {
 
     items_.push_back(new_item);
     meta_.emplace_back();
+
+    // Node::add_child() only queues into pending_children, and
+    // Node::flush_pending_children() recurses into *newly added* children only.
+    // A container that is already in the tree therefore never has its pending
+    // children applied, so items added after construction would never appear.
+    // Same idiom as TabContainer::reload_tab_buttons().
+    vbox_container_->flush_pending_children();
 }
 
 void PopupMenu::set_item_meta(uint32_t item_index, std::string meta) {


### PR DESCRIPTION
# Fix popup menu items lost after construction, plus two layout issues

Three independent bugs found while building a device-picker dropdown. Each is one commit; they can be taken separately.

---

## 1. Items added after the menu is in the tree never appear

**The bug.** Repopulating a `PopupMenu` after construction leaves it permanently empty.

**Why.** `PopupMenu::create_item()` calls `vbox_container_->add_child()`, which does not add anything — it queues into `pending_children` (`Node::add_child`). Those are applied by `Node::flush_pending_children()`, which recurses into **newly added** children only, and the sole top-level call is `root->flush_pending_children()`.

So a container already in the tree never has its pending children applied. Meanwhile `clear_items()` → `remove_all_children()` clears `children` *immediately*. The asymmetry is the whole bug:

| | at construction | when refreshed later |
|---|---|---|
| `clear_items()` | clears immediately | clears immediately |
| `create_item()` × N | queued | queued |
| flush | happens — subtree is still "new" | **never happens** |
| result | N items | **0 items** |

This is why it looks intermittent: it depends purely on whether the node was already in the tree.

**Fix.** Flush explicitly after adding an item — the same thing `TabContainer::reload_tab_buttons()` already does for its button container, so this follows existing practice in the codebase rather than introducing a new pattern.

**Reproduce.** Build a `MenuButton`, let a frame pass, then call `clear_items()` + `create_item()` again. The popup is empty afterwards.

---

## 2. A long popup item widens the button and everything around it

**The bug.** One entry with a long label stretches the button — and any container holding it, e.g. a sidebar — to that width, even while that entry is *not* selected.

**Why.** `MenuButton::calc_minimum_size()` did:

```cpp
calculated_minimum_size.x = std::max(menu->get_effective_minimum_size().x, calculated_minimum_size.x);
```

A minimum size propagates up through every parent container, so the contents of a menu end up dictating unrelated layout.

**Fix.** Let the button size to its own text. The popup is unaffected — `PopupMenu::adjust_layout()` already uses `max(size.x, margin_container_->get_effective_minimum_size().x)`, so the button width acts only as a *floor*. The list still renders at full width and simply overhangs the button, which is how dropdowns behave elsewhere. Nothing is truncated.

---

## 3. A popup wider than its button can fall off the window

**The bug.** With #2 fixed, a popup can legitimately be wider than its button. `adjust_layout()` anchored it at the button's `x` and grew rightwards, so a button near the right edge — a right-hand sidebar, say — pushed most of the list off screen where it could not be read or clicked.

**Fix.** Anchor to the button's left edge when there is room; otherwise shift left so the popup's right edge meets the window edge. Clamped at `0` so it can never run off the left side either.

---

## Testing

Built and exercised in a real application (an OpenIPC FPV ground station) whose sidebar hosts a USB-device dropdown that is rebuilt on demand:

- popup repopulates correctly on every refresh (previously empty after the first)
- a 45-character entry no longer changes the sidebar width
- the open list overhangs the sidebar and stays fully on screen and readable
- other `MenuButton`s in the app (channel, channel width, codec, language) are visually unchanged — their items are short, so #2 and #3 are no-ops for them

No API or behavioural change for callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
